### PR TITLE
Changed the ipv4 address formatting

### DIFF
--- a/net/net.go
+++ b/net/net.go
@@ -195,12 +195,12 @@ func UnixAddrToSockaddr(addr *net.UnixAddr) (syscall.Sockaddr, int) {
 func SockaddrToIPAndZone(sa syscall.Sockaddr) (net.IP, string) {
 	switch sa := sa.(type) {
 	case *syscall.SockaddrInet4:
-		ip := make([]byte, 16)
-		copy(ip[12:16], sa.Addr[:])
+		ip := make([]byte, len(sa.Addr))
+		copy(ip, sa.Addr[:])
 		return ip, ""
 
 	case *syscall.SockaddrInet6:
-		ip := make([]byte, 16)
+		ip := make([]byte, len(sa.Addr))
 		copy(ip, sa.Addr[:])
 		return ip, IP6ZoneToString(int(sa.ZoneId))
 	}


### PR DESCRIPTION
In the current implementation of func SockaddrToIPAndZone(), the length of the slice for both Ipv4 and Ipv6 are hardcoded as 16. Modified this to set the length based on the IP type ( i.e size 4 for Ipv4 and size 16 for Ipv6 accordingly)